### PR TITLE
terraform-aws 4.x compatability

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,6 +6,6 @@ terraform {
   required_version = ">= 0.12.20, < 2.0"
 
   required_providers {
-    aws = ">= 2.51, < 4.0"
+    aws = ">= 2.51, < 5.0"
   }
 }


### PR DESCRIPTION
enable terraform init with aws module >=4.0,<5.0 